### PR TITLE
corrected apiVersion and deployment yaml files for v1.16

### DIFF
--- a/K8s/descriptors/cart-deployment.yaml
+++ b/K8s/descriptors/cart-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
@@ -10,6 +10,9 @@ metadata:
   name: cart
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: cart
   strategy: {}
   template:
     metadata:

--- a/K8s/descriptors/catalogue-deployment.yaml
+++ b/K8s/descriptors/catalogue-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
@@ -10,6 +10,9 @@ metadata:
   name: catalogue
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: catalogue
   strategy: {}
   template:
     metadata:

--- a/K8s/descriptors/dispatch-deployment.yaml
+++ b/K8s/descriptors/dispatch-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
@@ -10,6 +10,9 @@ metadata:
   name: dispatch
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: dispatch
   strategy: {}
   template:
     metadata:

--- a/K8s/descriptors/mongodb-deployment.yaml
+++ b/K8s/descriptors/mongodb-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
@@ -10,6 +10,9 @@ metadata:
   name: mongodb
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: mongodb
   strategy: {}
   template:
     metadata:

--- a/K8s/descriptors/mysql-deployment.yaml
+++ b/K8s/descriptors/mysql-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
@@ -10,6 +10,9 @@ metadata:
   name: mysql
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: mysql
   strategy: {}
   template:
     metadata:

--- a/K8s/descriptors/payment-deployment.yaml
+++ b/K8s/descriptors/payment-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
@@ -10,6 +10,9 @@ metadata:
   name: payment
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: payment
   strategy: {}
   template:
     metadata:

--- a/K8s/descriptors/rabbitmq-deployment.yaml
+++ b/K8s/descriptors/rabbitmq-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
@@ -10,6 +10,9 @@ metadata:
   name: rabbitmq
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: rabbitmq
   strategy: {}
   template:
     metadata:

--- a/K8s/descriptors/ratings-deployment.yaml
+++ b/K8s/descriptors/ratings-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
@@ -10,6 +10,9 @@ metadata:
   name: ratings
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: ratings
   strategy: {}
   template:
     metadata:

--- a/K8s/descriptors/redis-deployment.yaml
+++ b/K8s/descriptors/redis-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
@@ -10,6 +10,9 @@ metadata:
   name: redis
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: redis
   strategy: {}
   template:
     metadata:

--- a/K8s/descriptors/shipping-deployment.yaml
+++ b/K8s/descriptors/shipping-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
@@ -10,6 +10,9 @@ metadata:
   name: shipping
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: shipping
   strategy: {}
   template:
     metadata:

--- a/K8s/descriptors/user-deployment.yaml
+++ b/K8s/descriptors/user-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
@@ -10,6 +10,9 @@ metadata:
   name: user
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: user
   strategy: {}
   template:
     metadata:

--- a/K8s/descriptors/web-deployment.yaml
+++ b/K8s/descriptors/web-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
@@ -10,6 +10,9 @@ metadata:
   name: web
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: web
   strategy: {}
   template:
     metadata:


### PR DESCRIPTION
Following "Kubernetes Essentials" on linuxacademy and since I couldn't create all the K8s deployments I corrected apiVersion to apps/v1 and added matching selector. I was using kubectl v1.16.

Now it works. Hope it's ok.

Cheers,
Zoran